### PR TITLE
Markdown fix: 'list', 'code block'.

### DIFF
--- a/app/data/lexlib/Markdown.lcf
+++ b/app/data/lexlib/Markdown.lcf
@@ -232,6 +232,14 @@ object SyntAnal67: TLibSyntAnalyzer
       ColumnTo = 0
     end
     item
+      DisplayName = 'Codeblock'
+      StyleName = 'Codeblock'
+      TokenType = 4
+      Expression = '^([\x20]{4,}|[\x09]{1,}).+$'#13#10'#Sometimes conflicts with Definition'
+      ColumnFrom = 0
+      ColumnTo = 0
+    end
+    item
       DisplayName = 'Footnote'
       StyleName = 'Footnote'
       TokenType = 7
@@ -244,7 +252,7 @@ object SyntAnal67: TLibSyntAnalyzer
       StyleName = 'List'
       TokenType = 13
       Expression = 
-        '^[\x20\x09]*(\d\.|\-\ |+\ |\*\ |\+\ |[\(]?[a-z\d]?[\.\)]{1})|'#13#10'^' +
+        '^[\x20\x09]*(\d{1,3}\.|\-\ |+\ |\*\ |\+\ |[\(]?[a-z\d]?[\.\)]{1})|'#13#10'^' +
         '\(@[^\)]*\)#pandoc list'
       ColumnFrom = 0
       ColumnTo = 0
@@ -274,14 +282,6 @@ object SyntAnal67: TLibSyntAnalyzer
       StyleName = 'Block'
       TokenType = 5
       Expression = '(?s)(^```|`).*?(^```|`)|'#13#10'(?s)^~~~.*?^~~~)'
-      ColumnFrom = 0
-      ColumnTo = 0
-    end
-    item
-      DisplayName = 'Codeblock'
-      StyleName = 'Codeblock'
-      TokenType = 4
-      Expression = '^[\x20\x09]{4,}.+$'#13#10'#Sometimes conflicts with Definition'
       ColumnFrom = 0
       ColumnTo = 0
     end

--- a/app/data/lexlib/Markdown.lcf
+++ b/app/data/lexlib/Markdown.lcf
@@ -235,7 +235,7 @@ object SyntAnal67: TLibSyntAnalyzer
       DisplayName = 'Codeblock'
       StyleName = 'Codeblock'
       TokenType = 4
-      Expression = '^([\x20]{4,}|[\x09]{1,}).+$'#13#10'#Sometimes conflicts with Definition'
+      Expression = '^(\x20{4,}|\x09{1,}).+$'#13#10'#Sometimes conflicts with Definition'
       ColumnFrom = 0
       ColumnTo = 0
     end


### PR DESCRIPTION
Нумерованные списки: работали только от 1 до 9, 10 и дальше не подсвечивались. Разширил диапазон от 1 до 999.
Повысил приоритет 'Codeblock', он конфликтовал со списками.
Изменил правило 'Codeblock' - 4 пробела или 1 табулятор (а не 4 табулятора как было раньше).