### PR TITLE
Markdown fix: 'symbol "&" incorrect syntax highlighting

### DIFF
--- a/app/data/lexlib/Markdown.lcf
+++ b/app/data/lexlib/Markdown.lcf
@@ -203,7 +203,7 @@ object SyntAnal24: TLibSyntAnalyzer
       DisplayName = 'HTML Code'
       StyleName = 'HTML Code'
       TokenType = 9
-      Expression = '\&[^;]+\; |'#13#10'</?\w+>'
+      Expression = '\&#?[a-zA-Z0-9]+\; |'#13#10'</?\w+>'
       ColumnFrom = 0
       ColumnTo = 0
     end


### PR DESCRIPTION
bug: 'symbol "&" infected _all_ subsequent text with incorrect syntax highlighting (up to the character ";")
fix: "HTML Entities" (HTML Code) - change regular expression to standard