### PR TITLE
Fix single instance command line parameters, folder and directory

### DIFF
--- a/app/fix_focus_window.pas
+++ b/app/fix_focus_window.pas
@@ -21,6 +21,7 @@ uses
   proc_globdata,
   proc_msg,
   at__jsonconf,
+  LazFileUtils,
   {$endif}
   SysUtils,
   LCLIntf;
@@ -342,8 +343,8 @@ function IsAnotherInstanceRunning:boolean;
 var
   i: Integer;
   cli: String;
-  sourceDir: Array[0..MAX_PATH] of WideChar;
   workDir: String;
+  parameter: String;
 begin
 
   Result := False;
@@ -355,23 +356,23 @@ begin
     case FInstanceManage.Status of
       isSecond:
         begin
-          GetCurrentDirectoryW(SizeOf(sourceDir), sourceDir);
-          workDir := string(sourceDir);
+          workDir := GetCurrentDirUTF8;
           if LowerCase(ExtractFileDir(ParamStrUTF8(0))) = LowerCase(workDir) then
             workDir := '';
           cli := '';
           for i := 1 to ParamCount do
           begin
+            parameter := ParamStrUTF8(i);
             // flags (-) won't be processed since instance is already running
             if workDir <> '' then
             begin
-              if Pos(':', ParamStrUTF8(i)) = 2 then
-                cli := cli + ParamStrUTF8(i) + ParamsSeparator
+              if Pos(':', parameter) = 2 then
+                cli := cli + parameter + ParamsSeparator
               else
-                cli := cli + workDir + '\' + ParamStrUTF8(i) + ParamsSeparator;
+                cli := cli + workDir + '\' + parameter + ParamsSeparator;
             end
             else
-              cli := cli + ParamStrUTF8(i) + ParamsSeparator;
+              cli := cli + parameter + ParamsSeparator;
           end;
           FInstanceManage.ActivateFirstInstance(BytesOf(cli));
           Sleep(100);

--- a/app/formmain.pas
+++ b/app/formmain.pas
@@ -1356,7 +1356,7 @@ begin
       //if dir, open in ProjManager
       if DirectoryExistsUTF8(SFilename) then
       begin
-        DoFolderOpen(SFilename, True);
+        DoFolderOpen(SFilename, False);
       end
       else
       if FileExistsUTF8(SFilename) then

--- a/app/formmain.pas
+++ b/app/formmain.pas
@@ -1353,6 +1353,12 @@ begin
     begin
       SFilename := params[i];
       SParseFilenameWithTwoNumbers(SFilename, NLine, NColumn);
+      //if dir, open in ProjManager
+      if DirectoryExistsUTF8(SFilename) then
+      begin
+        DoFolderOpen(SFilename, True);
+      end
+      else
       if FileExistsUTF8(SFilename) then
       begin
         Frame:= DoFileOpen(SFilename);


### PR DESCRIPTION
Fix issue #1482 on Windows 

Now it can open files or folders from command line using relative path while Single Instance "ui_one_instance" is set to true.

e.g. if alias 'cuda' is a global PATH to cudatext.exe

> cuda .

> cuda readme.md

> cuda c:\somepath\file.txt

> cuda "d:\some spaced path\projectdir"

> cuda ..\fileinparentdir.txt