### PR TITLE
fix lexer regex for JS template literals

### DIFF
--- a/app/data/lexlib/JavaScript.lcf
+++ b/app/data/lexlib/JavaScript.lcf
@@ -175,7 +175,7 @@ object SyntAnal10: TLibSyntAnalyzer
       DisplayName = 'String ticks'
       StyleName = 'String regex'
       TokenType = 4
-      Expression = '(?s)`.+?(`|\Z)'
+      Expression = '(?s)`(\\`|.)*?(`|\Z)'
       ColumnFrom = 0
       ColumnTo = 0
     end


### PR DESCRIPTION
currently the JS lexer doesn't recognise empty strings (\`\`) or escaped ticks (\`\\\`\`) in the template literal syntax.

this seems to fix it.