### PR TITLE
fixed windows cuda_tree_xml plugin show "SyntaxError: (unicode error)…

### DIFF
--- a/app/formmain_py_helpers.inc
+++ b/app/formmain_py_helpers.inc
@@ -186,7 +186,7 @@ begin
         try
           ExecString('import '+ItemModule);
           Obj:= EvalString(
-            Format('%s.%s("%s", text)', [ItemModule, ItemProc, Frame.GetFileName(Ed)]),
+            Format('%s.%s("%s", text)', [ItemModule, ItemProc, Frame.GetFileName(Ed).Replace('\','/')]),
             ObjLocals, //locals
             nil //globals
             );


### PR DESCRIPTION
… 'unicodeescape' codec can't decode bytes in position 2-3: truncated \UXXXXXXXX escape".

use cuda_tree_xml ,if edited filename is "C:\Users\admin\Desktop\test.xml",show error.