### PR TITLE
Improve lexer for VB, VB .NET and VBScript

### DIFF
--- a/app/data/lexlib/VBScript.lcf
+++ b/app/data/lexlib/VBScript.lcf
@@ -123,7 +123,7 @@ object SyntAnal37: TLibSyntAnalyzer
     item
       DisplayName = 'String'
       StyleName = 'String'
-      TokenType = 8
+      TokenType = 4
       Expression = '".*?("|$)'
       ColumnFrom = 0
       ColumnTo = 0
@@ -131,31 +131,23 @@ object SyntAnal37: TLibSyntAnalyzer
     item
       DisplayName = 'Label'
       StyleName = 'Label'
-      TokenType = 10
+      TokenType = 6
       Expression = '^\x20*\w+:'
       ColumnFrom = 0
       ColumnTo = 0
     end
     item
-      DisplayName = 'Id_spec_if'
+      DisplayName = 'Id_spec_beginif'
       StyleName = 'Reserved word'
-      TokenType = 3
-      Expression = '\b if \b (?=\x20* .*? \x20+ then \x20*)'
-      ColumnFrom = 0
-      ColumnTo = 0
-    end
-    item
-      DisplayName = 'Id_spec_then'
-      StyleName = 'Reserved word'
-      TokenType = 4
-      Expression = '\b then \x20* $'
+      TokenType = 7
+      Expression = '\b if \b (?= .*? (\b then \x20* | \x20 _) $)'
       ColumnFrom = 0
       ColumnTo = 0
     end
     item
       DisplayName = 'Id_spec_endif'
       StyleName = 'Reserved word'
-      TokenType = 5
+      TokenType = 8
       Expression = '\b end \x20+ if \b'
       ColumnFrom = 0
       ColumnTo = 0
@@ -163,7 +155,7 @@ object SyntAnal37: TLibSyntAnalyzer
     item
       DisplayName = 'Id_spec_next'
       StyleName = 'Reserved word'
-      TokenType = 6
+      TokenType = 9
       Expression = '\b next \x20* $'
       ColumnFrom = 0
       ColumnTo = 0
@@ -179,7 +171,7 @@ object SyntAnal37: TLibSyntAnalyzer
     item
       DisplayName = 'Float'
       StyleName = 'Number'
-      TokenType = 9
+      TokenType = 5
       Expression = '\d+ \.? \d+ e [\+\-]? \d+ |'#13#10'\d+ \. \d+ '
       ColumnFrom = 0
       ColumnTo = 0
@@ -187,7 +179,7 @@ object SyntAnal37: TLibSyntAnalyzer
     item
       DisplayName = 'Integer'
       StyleName = 'Number'
-      TokenType = 9
+      TokenType = 5
       Expression = '\d+'
       ColumnFrom = 0
       ColumnTo = 0
@@ -195,7 +187,7 @@ object SyntAnal37: TLibSyntAnalyzer
     item
       DisplayName = 'Hex'
       StyleName = 'Number'
-      TokenType = 9
+      TokenType = 5
       Expression = '&H[\da-f]+&? |'#13#10'&o[0-7]+'
       ColumnFrom = 0
       ColumnTo = 0
@@ -211,7 +203,7 @@ object SyntAnal37: TLibSyntAnalyzer
     item
       DisplayName = 'Symbol single'
       StyleName = 'Symbol'
-      TokenType = 7
+      TokenType = 3
       Expression = '[\(\)\{\}\[\]]'
       ColumnFrom = 0
       ColumnTo = 0
@@ -219,7 +211,7 @@ object SyntAnal37: TLibSyntAnalyzer
     item
       DisplayName = 'Symbol'
       StyleName = 'Symbol'
-      TokenType = 7
+      TokenType = 3
       Expression = '[/,\.;:=<>\+\-\*&%\^\$!@~]+'
       ColumnFrom = 0
       ColumnTo = 0
@@ -331,6 +323,7 @@ object SyntAnal37: TLibSyntAnalyzer
             'typeof'
             'unlock'
             'until'
+            'using'
             'variant'
             'wend'
             'while'
@@ -640,23 +633,16 @@ object SyntAnal37: TLibSyntAnalyzer
     end
     item
       DisplayName = 'Begin if'
+      StyleName = 'Current block bound'
       ConditionList = <
         item
-          TokenTypes = 16
-          IgnoreCase = True
-        end
-        item
-          CondType = tcSkip
-          TokenTypes = 901
-          IgnoreCase = True
-        end
-        item
-          TokenTypes = 8
+          TokenTypes = 128
           IgnoreCase = True
         end>
       BlockEnd = 'End if'
       DisplayInTree = False
-      HighlightPos = cpAny
+      DynHighlight = dhBound
+      HighlightPos = cpRange
       DrawStaple = True
       CollapseFmt = '%sz0'
       IgnoreAsParent = False
@@ -666,7 +652,7 @@ object SyntAnal37: TLibSyntAnalyzer
       BlockType = btRangeEnd
       ConditionList = <
         item
-          TokenTypes = 32
+          TokenTypes = 256
           IgnoreCase = True
         end>
       HighlightPos = cpAny
@@ -704,7 +690,7 @@ object SyntAnal37: TLibSyntAnalyzer
       BlockType = btRangeEnd
       ConditionList = <
         item
-          TokenTypes = 64
+          TokenTypes = 512
           IgnoreCase = True
         end
         item
@@ -721,6 +707,7 @@ object SyntAnal37: TLibSyntAnalyzer
     end
     item
       DisplayName = 'Begin Do'
+      StyleName = 'Current block bound'
       ConditionList = <
         item
           TagList.Strings = (
@@ -737,7 +724,8 @@ object SyntAnal37: TLibSyntAnalyzer
         end>
       BlockEnd = 'End Do'
       DisplayInTree = False
-      HighlightPos = cpAny
+      DynHighlight = dhBound
+      HighlightPos = cpRange
       DrawStaple = True
       CollapseFmt = '%sz0'
       IgnoreAsParent = False
@@ -757,6 +745,7 @@ object SyntAnal37: TLibSyntAnalyzer
     end
     item
       DisplayName = 'Begin While'
+      StyleName = 'Current block bound'
       ConditionList = <
         item
           TagList.Strings = (
@@ -766,7 +755,8 @@ object SyntAnal37: TLibSyntAnalyzer
         end>
       BlockEnd = 'End While'
       DisplayInTree = False
-      HighlightPos = cpAny
+      DynHighlight = dhBound
+      HighlightPos = cpRange
       DrawStaple = True
       CollapseFmt = '%sz0'
       IgnoreAsParent = False
@@ -809,10 +799,10 @@ object SyntAnal37: TLibSyntAnalyzer
     '    Wend'
     ''
     '    '#39'don'#39't fold If'
-    
+
       '    '#39'don'#39't interpret Exit Property as beginning of property gett' +
       '/setter'
-    
+
       '    If intValue <> vbCrLf And intValue <> vbLf Then Exit Propert' +
       'y'
     ''
@@ -890,6 +880,18 @@ object SyntAnal37: TLibSyntAnalyzer
     '      I = 1'
     '    End If'
     ''
+    '   '#39'if with multi-line condition and one-line if...then'
+    '    If I = 0 Or_'
+    '       I = 2 Then'
+    '      I = -1'
+    '      If X = 4 Then I = -2'
+    '    ElseIf I = 1 Or _'
+    '           I = 3 Then'
+    '      If X = 5 Then I = 0'
+    '    Else'
+    '      I = 1'
+    '    End If'
+    ''
     '    For I = 0 To Number'
     '      X = X + &hFF'
     '      X = X - &o7'
@@ -912,14 +914,13 @@ object SyntAnal37: TLibSyntAnalyzer
     'Unknown'
     'Comment'
     'Identifier'
-    'Id_spec_If'
-    'Id_spec_Then'
-    'Id_spec_EndIf'
-    'Id_spec_Next'
     'Symbol'
     'String'
     'Number'
-    'Label')
+    'Label'
+    'Id_spec_BeginIf'
+    'Id_spec_EndIf'
+    'Id_spec_Next')
   Extentions = 'vb vbs'
   LexerName = 'VBScript'
   Notes.Strings = (


### PR DESCRIPTION
* Fix regression - code folding of "If" statements with multi-line condition expressions failed
* Add highlighting of bounding tokens for "If...End If", "Do...Loop" and "While...Wend" (only visible in SynWrite)