### PR TITLE
Improve lexer for Windows Batch script

### DIFF
--- a/app/data/lexlib/Batch files.lcf
+++ b/app/data/lexlib/Batch files.lcf
@@ -428,6 +428,7 @@ object SyntAnal5: TLibSyntAnalyzer
             'wusa'
             'xcopy')
           TokenTypes = 4
+          IgnoreCase = True
         end>
       HighlightPos = cpAny
       IgnoreAsParent = False


### PR DESCRIPTION
* Fix regression - external commands have been searched case sensitive.