### PR TITLE
Fix various typos

### DIFF
--- a/app/cudatext.app/Contents/Resources/data/autocomplete/Batch files.acp
+++ b/app/cudatext.app/Contents/Resources/data/autocomplete/Batch files.acp
@@ -68,7 +68,7 @@ Command ECHO |Display text on screen
 Command EDIT |Text editor in MS-DOS 5+ (requires QBASIC)
 Command EDLIN |Line editor in MS-DOS 4-
 Command ENDLOCAL |Terminate local environment
-Command EPAL |Elevated Priviliges Application Launcher (free Microsoft download)
+Command EPAL |Elevated Privileges Application Launcher (free Microsoft download)
 Command ERASE |Delete one or more files
 Command EVENTCREATE |Write an event in one of the event logs
 Command EVENTQUERY.VBS |List events and event properties
@@ -88,7 +88,7 @@ Command FINDSTR |Search files or standard output with advanced options
 Command FOR |Loop through a set of files or variables
 Command FORCEDOS |Force XP to start the specified program in the MS-DOS subsystem
 Command FORFILES |Selects and executes a command on a file or set of files
-Command FORMAT |Format disks (intialize file system)
+Command FORMAT |Format disks (initialize file system)
 Command FSUTIL |Manage FAT and NTFS file systems (XP)
 Command FTP |File Transfer Protocol client
 Command FTYPE |Display or define the "Open" command for a file type
@@ -188,7 +188,7 @@ Command ROUTE |Display and modify the entries in the local IP routing table
 Command RUNAS |Run a command with different credentials (will always prompt for a password; use CPAU if you need to make this unattended)
 Command RUNDLL |Command line wrapper for 16-bit DLL routines
 Command RUNDLL32 |Command line wrapper for 32-bit DLL routines
-Command SC |Command line services managment (XP)
+Command SC |Command line services management (XP)
 Command SCHTASKS |Command line task scheduler (XP)
 Command SECEDIT |Configure and analyze system security by comparing your current configuration to a template (Windows 2000+)
 Command SET |Manipulate environment variables

--- a/app/cudatext.app/Contents/Resources/data/autocomplete/PHP_.acp
+++ b/app/cudatext.app/Contents/Resources/data/autocomplete/PHP_.acp
@@ -1654,7 +1654,7 @@ bool imap_close(resource $imap_stream [, int $flag=0]) |Close an IMAP stream (PH
 bool imap_createmailbox(resource $imap_stream, string $mailbox) |Create a new mailbox (PHP 4, PHP 5)
 bool imap_delete(resource $imap_stream, int $msg_number [, int $options=0]) |Mark a message for deletion from current mailbox (PHP 4, PHP 5)
 bool imap_deletemailbox(resource $imap_stream, string $mailbox) |Delete a mailbox (PHP 4, PHP 5)
-array imap_errors() |Returns all of the IMAP errors that have occured (PHP 4, PHP 5)
+array imap_errors() |Returns all of the IMAP errors that have occurred (PHP 4, PHP 5)
 bool imap_expunge(resource $imap_stream) |Delete all messages marked for deletion (PHP 4, PHP 5)
 array imap_fetch_overview(resource $imap_stream, string $sequence [, int $options=0]) |Read an overview of the information in the headers of the given message (PHP 4, PHP 5)
 string imap_fetchbody(resource $imap_stream, int $msg_number, string $section [, int $options=0]) |Fetch a particular section of the body of the message (PHP 4, PHP 5)
@@ -2367,7 +2367,7 @@ int mysqli_thread_id(mysqli $link) |The mysqli_thread_id() function returns the 
 bool mysqli_thread_safe(void) |Tells whether the client library is compiled as thread-safe. (PHP 5, PHP 7)
 mysqli_result mysqli_use_result(mysqli $link) |Used to initiate the retrieval of a result set from the last query executed using the mysqli_real_query() function on the database connection. (PHP 5, PHP 7)
 #Summary of mysqli_stmt methods
-int mysqli_stmt_affected_rows(mysqli_stmt $stmt) |mysqli_stmt::$affected_rows -- mysqli_stmt_affected_rows — Returns the total number of rows changed, deleted, or inserted by the last executed statement. (PHP 5, PHP 7)
+int mysqli_stmt_affected_rows(mysqli_stmt $stmt) |mysqli_stmt::$affected_rows -- mysqli_stmt_affected_rows ï¿½ Returns the total number of rows changed, deleted, or inserted by the last executed statement. (PHP 5, PHP 7)
 int mysqli_stmt_errno(mysqli_stmt $stmt) |Returns the error code for the most recently invoked statement function that can succeed or fail. (PHP 5, PHP 7)
 string mysqli_stmt_error(mysqli_stmt $stmt) |Returns a string containing the error message for the most recently invoked statement function that can succeed or fail. (PHP 5, PHP 7)
 int mysqli_stmt_field_count(mysqli_stmt $stmt) |Returns the number of field in the given statement. (PHP 5, PHP 7)

--- a/app/cudatext.app/Contents/Resources/py/cuda_addonman/__init__.py
+++ b/app/cudatext.app/Contents/Resources/py/cuda_addonman/__init__.py
@@ -190,7 +190,7 @@ class Command:
 
         text = _('Download complete') if not self.stopped_force else _('Download stopped ')+self.stopped_msg
         if err>0:
-            text += _('\nErrors occured, see Python console')
+            text += _('\nErrors occurred, see Python console')
         msg_box(text, MB_OK+MB_ICONINFO)
 
 

--- a/app/cudatext.app/Contents/Resources/py/cuda_comments/cd_comments.py
+++ b/app/cudatext.app/Contents/Resources/py/cuda_comments/cd_comments.py
@@ -111,7 +111,7 @@ class Command:
         pass;                  #log('cmt_type, lex, cmt_sgn={}', (cmt_type, lex, cmt_sgn))
         if not cmt_sgn:
             return app.msg_status(f(_('Lexer "{}" doesn\'t support "line comments"'), lex))
-        # Analize
+        # Analyze
         empty_sel   = False
         rWrks       = []
         use_rep_lines = True # use API replace_lines()

--- a/app/cudatext.app/Contents/Resources/py/cuda_comments/cd_plug_lib.py
+++ b/app/cudatext.app/Contents/Resources/py/cuda_comments/cd_plug_lib.py
@@ -346,7 +346,7 @@ def dlg_wrapper(title, w, h, cnts, in_vals={}, focus_cid=None):
             title, w, h     Title, Width, Height 
             cnts            List of static control properties
                                 [{cid:'*', tp:'*', t:1,l:1,w:1,r:1,b;1,h:1, cap:'*', hint:'*', en:'0', props:'*', items:[*], valign_to:'cid'}]
-                                cid         (opt)(str) C(ontrol)id. Need only for buttons and conrols with value (and for tid)
+                                cid         (opt)(str) C(ontrol)id. Need only for buttons and controls with value (and for tid)
                                 tp               (str) Control types from wiki or short names
                                 t           (opt)(int) Top
                                 tid         (opt)(str) Ref to other control cid for horz-align text in both controls

--- a/app/cudatext.app/Contents/Resources/py/cuda_options_editor/cd_opts_dlg.py
+++ b/app/cudatext.app/Contents/Resources/py/cuda_options_editor/cd_opts_dlg.py
@@ -2269,7 +2269,7 @@ ToDo
 [+][kv-kv][02apr17] History for cond
 [-][kv-kv][02apr17] ? Chapters list and "chap" attr into kinfo
 [-][kv-kv][02apr17] ? Tags list and "tag" attr into kinfo
-[-][kv-kv][02apr17] ? Delimeter row in table
+[-][kv-kv][02apr17] ? Delimiter row in table
 [ ][kv-kv][02apr17] "Need restart" in Comments
 [+][kv-kv][02apr17] ? Calc Format by Def_val
 [ ][kv-kv][02apr17] int_mm for min+max
@@ -2299,7 +2299,7 @@ ToDo
 [?][kv-kv][20mar18] Allow to add/remove opt in user/lex
 [?][kv-kv][21mar18] ? Allow to meta keys in user.json: 
                         "_fif_LOG__comment":"Comment for fif_LOG"
-[+][kv-kv][22mar18] Set conrol's tab_order to always work Alt+E for "Valu&e"
+[+][kv-kv][22mar18] Set control's tab_order to always work Alt+E for "Valu&e"
 [ ][kv-kv][26mar18] Use 'editor' for comment
 [+][kv-kv][26mar18] Increase w for one col when user increases w of dlg (if no h-scroll)
 [+][kv-kv][13apr18] DClick on Def-col - focus to Reset

--- a/app/cudatext.app/Contents/Resources/py/cuda_options_editor/cd_plug_lib.py
+++ b/app/cudatext.app/Contents/Resources/py/cuda_options_editor/cd_plug_lib.py
@@ -245,9 +245,9 @@ def get_desktop_environment():
         return "win"
     elif sys.platform == "darwin":
         return "mac"
-    else: #Most likely either a POSIX system or something not much common
+    else: #Most likely either a POSIX system or something less common
         desktop_session = os.environ.get("DESKTOP_SESSION")
-        if desktop_session is not None: #easier to match if we doesn't have  to deal with caracter cases
+        if desktop_session is not None: #easier to match if we don' have to deal with character cases
             desktop_session = desktop_session.lower()
             if desktop_session in ["gnome","unity", "cinnamon", "mate", "xfce4", "lxde", "fluxbox", 
                                    "blackbox", "openbox", "icewm", "jwm", "afterstep","trinity", "kde"]:
@@ -360,7 +360,7 @@ def dlg_wrapper(title, w, h, cnts, in_vals={}, focus_cid=None):
             title, w, h     Title, Width, Height 
             cnts            List of static control properties
                                 [{cid:'*', tp:'*', t:1,l:1,w:1,r:1,b;1,h:1,tid:'cid', cap:'*', hint:'*', en:'0', props:'*', items:[*], act='0'}]
-                                cid         (opt)(str) C(ontrol)id. Need only for buttons and conrols with value (and for tid)
+                                cid         (opt)(str) C(ontrol)id. Need only for buttons and controls with value (and for tid)
                                 tp               (str) Control types from wiki or short names
                                 t           (opt)(int) Top
                                 tid         (opt)(str) Ref to other control cid for horz-align text in both controls
@@ -826,7 +826,7 @@ class BaseDlgAgent:
             return {'ctrls':  [(name,{...})]    #   To change controls with the names
                    ,'form':   {...}             #   To change form
                    ,'focused':name_to_focus     #   To set focus
-                   }                            #   Any key ('ctrls','form','focused') can be ommited.
+                   }                            #   Any key ('ctrls','form','focused') can be omitted.
     Callback cannot add new controls or change type values.
     
     Useful methods of agent
@@ -999,7 +999,7 @@ class BaseDlgAgent:
                         , DLG_CTL_ADD_SET
                         , name=cfg_ctrl['type']
                         , prop=self._prepare_c_pr(name, cfg_ctrl))
-            pass;              #cfg_ctrl['_idc']    = ind_c         # While API bug: name isnot work if contorl is in panel
+            pass;              #cfg_ctrl['_idc']    = ind_c         # While API bug: name isnot work if control is in panel
             pass;              #log('ind_c,cfg_ctrl[type]={}',(ind_c,cfg_ctrl['type']))
            #for cnt
         
@@ -1390,10 +1390,10 @@ class DlgAgent(BaseDlgAgent):
         live-attr - actual attribute     (key and value taked from dlg_proc)
     
     Rules
-    1. All conrols have conf-attr 'cid'|'name'. It must be unique.
-    2. All conrols have conf-attr 'tp'|'type'. 
+    1. All controls have conf-attr 'cid'|'name'. It must be unique.
+    2. All controls have conf-attr 'tp'|'type'. 
         Value of 'tp'|'type' can be any API values or shortened variants from REDUCTIONS.
-    3. Conrol position can be set 
+    3. Control position can be set 
         - directly by x,y,w,h
         - computed by enough subset of l,r,w,t,b,h (x=l, y=t, l+w=r, t+h=b)
         - computed by tid (refer to cid|name of control, from which to get t and add a bit to align texts)
@@ -1427,7 +1427,7 @@ class DlgAgent(BaseDlgAgent):
                    ,'form':{...}                #   To change form attributes
                    ,'focused':name_to_focus     #   To change focus
                    ,'fid':cid_to_focus          #   To change focus
-                   }                            #   Any key ('ctrls','vals','form','fid','focused') can be ommited.
+                   }                            #   Any key ('ctrls','vals','form','fid','focused') can be omitted.
         Callback cannot add/del controls or change cid,type,a,aid
         Callback have to conside the form as it has initial size - agent will recalculate to actual state.
         Useful methods of agent
@@ -1508,7 +1508,7 @@ class DlgAgent(BaseDlgAgent):
         return {cid:self.cattr(cid, 'val', live=live) for cid in cids}
     
     def _setup(self, ctrls, vals=None, form=None, fid=None):
-        """ Arrange and fill all: controls static/dinamic attrs, form attrs, focus.
+        """ Arrange and fill all: controls static/dynamic attrs, form attrs, focus.
             Params
                 ctrls   [{}]
                 vals    {cid:v}
@@ -1548,7 +1548,7 @@ class DlgAgent(BaseDlgAgent):
                         , DLG_CTL_ADD_SET
                         , name=cfg_ctrl['type']
                         , prop=self._prepare_c_pr(cid, cfg_ctrl))
-            pass;              #cfg_ctrl['_idc']    = ind_c         # While API bug: name isnot work if contorl is in panel
+            pass;              #cfg_ctrl['_idc']    = ind_c         # While API bug: name isnot work if control is in panel
            #for cnt
 
         # Resize callback
@@ -1763,7 +1763,7 @@ class DlgAgent(BaseDlgAgent):
                 trg_h   = prTrg['w'], prTrg['h']
             prOld   = dlg_proc_wpr(self.id_dlg, app.DLG_CTL_PROP_GET, name=cid)
             pass;              #prOld   = prOld if prOld else \
-                     #dlg_proc_wpr(self.id_dlg, app.DLG_CTL_PROP_GET, index=self.ctrls[cid]['_idc'])    # While API bug: name isnot work if contorl is in panel
+                     #dlg_proc_wpr(self.id_dlg, app.DLG_CTL_PROP_GET, index=self.ctrls[cid]['_idc'])    # While API bug: name isnot work if control is in panel
             pass;               logb=cid in ('tolx', 'tofi')
             pass;              #nat_prOld=app.dlg_proc(self.id_dlg, app.DLG_CTL_PROP_GET, name=cid)
             pass;              #log('cid,nat-prOld={}',(cid,{k:v for k,v in nat_prOld.items() if k in ('x','y','w','h','_ready_h')})) if logb else 0

--- a/app/cudatext.app/Contents/Resources/py/cuda_options_editor/readme/readme.txt
+++ b/app/cudatext.app/Contents/Resources/py/cuda_options_editor/readme/readme.txt
@@ -9,7 +9,7 @@ Options are shown in a table, after clicking an option you can see its default v
 - For boolean opts, checkbox is shown to change.
 - For string/number opts, input is shown to change.
 - For opts with limited count of values, combobox is used to choose one variant.
-- For font-name opts, combobox is shown (it lists special OS-dependant "default" font and OS fonts).
+- For font-name opts, combobox is shown (it lists special OS-dependent "default" font and OS fonts).
 
 Dialog gives "=" hamburger button with advanvced commands. For ex, command to create HTML report for options. And you can toggle option "Instant filtering" there, so you don't need to press Enter in the filter field.
 

--- a/app/cudatext.app/Contents/Resources/py/cuda_palette/cd_plug_lib.py
+++ b/app/cudatext.app/Contents/Resources/py/cuda_palette/cd_plug_lib.py
@@ -351,7 +351,7 @@ def dlg_wrapper(title, w, h, cnts, in_vals={}, focus_cid=None):
             title, w, h     Title, Width, Height 
             cnts            List of static control properties
                                 [{cid:'*', tp:'*', t:1,l:1,w:1,r:1,b;1,h:1,tid:'cid', cap:'*', hint:'*', en:'0', props:'*', items:[*], act='0'}]
-                                cid         (opt)(str) C(ontrol)id. Need only for buttons and conrols with value (and for tid)
+                                cid         (opt)(str) C(ontrol)id. Need only for buttons and controls with value (and for tid)
                                 tp               (str) Control types from wiki or short names
                                 t           (opt)(int) Top
                                 tid         (opt)(str) Ref to other control cid for horz-align text in both controls

--- a/app/cudatext.app/Contents/Resources/py/cuda_prefs/cd_opts_dlg.py
+++ b/app/cudatext.app/Contents/Resources/py/cuda_prefs/cd_opts_dlg.py
@@ -475,7 +475,7 @@ class OptEdD:
         """ Prepares values for and calls - `do_setv()`
             * action -- set, remove
             * scope -- m.for_ulf -- 'u','l','f' (user, lexer, file)
-            * opname -- optio nname -- m.cur_op
+            * opname -- option name -- m.cur_op
             * lexer -- m.lexr
             * apply_ -- apply options - set True on last option  or  on btn_apply
         """

--- a/app/cudatext.app/Contents/Resources/py/cuda_prefs/dlg.py
+++ b/app/cudatext.app/Contents/Resources/py/cuda_prefs/dlg.py
@@ -46,7 +46,7 @@ import time
 #TODO:
 
 ?
-* different color fo unapplied propery value in editor?
+* different color fo unapplied property value in editor?
 * list changes in dlg-statusbar + hover popup
 * editor line state coloring for modified/unapplied("saved") options?
 * show user/lexer/file option-values for selected option?
@@ -1036,7 +1036,7 @@ class DialogMK2:
             if val == _old_val: # no change - ignore
                 return
         else:  ### removing value
-            if _old_val is None: # no chage - ignore
+            if _old_val is None: # no change - ignore
                 return
 
         # if resetting value -- ask confirmation

--- a/app/cudatext.app/Contents/Resources/py/cuda_prefs/readme/readme.txt
+++ b/app/cudatext.app/Contents/Resources/py/cuda_prefs/readme/readme.txt
@@ -9,7 +9,7 @@ Options are shown in a table, after clicking an option you can see its current v
 - For boolean opts, checkbox is shown to change.
 - For string/number opts, input is shown to change.
 - For opts with limited count of values, combobox is used to choose one variant.
-- For font-name opts, combobox is shown (it lists special OS-dependant "default" font and OS fonts).
+- For font-name opts, combobox is shown (it lists special OS-dependent "default" font and OS fonts).
 
 Clicking on the list header displays a menu to choose visible columns and configure widths.
 

--- a/app/cudatext.app/Contents/Resources/py/cuda_snippet_panel/utils.py
+++ b/app/cudatext.app/Contents/Resources/py/cuda_snippet_panel/utils.py
@@ -27,8 +27,8 @@ def bom_type(file):
     if (b[0:3] == b'\xef\xbb\xbf'):
         return "utf8"
 
-    # Python automatically detects endianess if utf-16 bom is present
-    # write endianess generally determined by endianess of CPU
+    # Python automatically detects endianness if utf-16 bom is present
+    # write endianness generally determined by endianness of CPU
     if ((b[0:2] == b'\xfe\xff') or (b[0:2] == b'\xff\xfe')):
         return "utf16"
 

--- a/app/cudatext.app/Contents/Resources/py/sys/chardet/metadata/languages.py
+++ b/app/cudatext.app/Contents/Resources/py/sys/chardet/metadata/languages.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import, print_function
 from string import ascii_letters
 
 
-# TODO: Add Ukranian (KOI8-U)
+# TODO: Add Ukrainian (KOI8-U)
 
 class Language(object):
     """Metadata about a language useful for training models

--- a/app/cudatext.app/Contents/Resources/py/sys/chardet/sbcharsetprober.py
+++ b/app/cudatext.app/Contents/Resources/py/sys/chardet/sbcharsetprober.py
@@ -127,7 +127,7 @@ class SingleByteCharSetProber(CharSetProber):
                     self._state = ProbingState.FOUND_IT
                 elif confidence < self.NEGATIVE_SHORTCUT_THRESHOLD:
                     self.logger.debug('%s confidence = %s, below negative '
-                                      'shortcut threshhold %s', charset_name,
+                                      'shortcut threshold %s', charset_name,
                                       confidence,
                                       self.NEGATIVE_SHORTCUT_THRESHOLD)
                     self._state = ProbingState.NOT_ME

--- a/app/data/autocomplete/Batch files.acp
+++ b/app/data/autocomplete/Batch files.acp
@@ -68,7 +68,7 @@ Command ECHO |Display text on screen
 Command EDIT |Text editor in MS-DOS 5+ (requires QBASIC)
 Command EDLIN |Line editor in MS-DOS 4-
 Command ENDLOCAL |Terminate local environment
-Command EPAL |Elevated Priviliges Application Launcher (free Microsoft download)
+Command EPAL |Elevated Privileges Application Launcher (free Microsoft download)
 Command ERASE |Delete one or more files
 Command EVENTCREATE |Write an event in one of the event logs
 Command EVENTQUERY.VBS |List events and event properties
@@ -88,7 +88,7 @@ Command FINDSTR |Search files or standard output with advanced options
 Command FOR |Loop through a set of files or variables
 Command FORCEDOS |Force XP to start the specified program in the MS-DOS subsystem
 Command FORFILES |Selects and executes a command on a file or set of files
-Command FORMAT |Format disks (intialize file system)
+Command FORMAT |Format disks (initialize file system)
 Command FSUTIL |Manage FAT and NTFS file systems (XP)
 Command FTP |File Transfer Protocol client
 Command FTYPE |Display or define the "Open" command for a file type
@@ -188,7 +188,7 @@ Command ROUTE |Display and modify the entries in the local IP routing table
 Command RUNAS |Run a command with different credentials (will always prompt for a password; use CPAU if you need to make this unattended)
 Command RUNDLL |Command line wrapper for 16-bit DLL routines
 Command RUNDLL32 |Command line wrapper for 32-bit DLL routines
-Command SC |Command line services managment (XP)
+Command SC |Command line services management (XP)
 Command SCHTASKS |Command line task scheduler (XP)
 Command SECEDIT |Configure and analyze system security by comparing your current configuration to a template (Windows 2000+)
 Command SET |Manipulate environment variables

--- a/app/data/autocomplete/PHP_.acp
+++ b/app/data/autocomplete/PHP_.acp
@@ -1654,7 +1654,7 @@ bool imap_close(resource $imap_stream [, int $flag=0]) |Close an IMAP stream (PH
 bool imap_createmailbox(resource $imap_stream, string $mailbox) |Create a new mailbox (PHP 4, PHP 5)
 bool imap_delete(resource $imap_stream, int $msg_number [, int $options=0]) |Mark a message for deletion from current mailbox (PHP 4, PHP 5)
 bool imap_deletemailbox(resource $imap_stream, string $mailbox) |Delete a mailbox (PHP 4, PHP 5)
-array imap_errors() |Returns all of the IMAP errors that have occured (PHP 4, PHP 5)
+array imap_errors() |Returns all of the IMAP errors that have occurred (PHP 4, PHP 5)
 bool imap_expunge(resource $imap_stream) |Delete all messages marked for deletion (PHP 4, PHP 5)
 array imap_fetch_overview(resource $imap_stream, string $sequence [, int $options=0]) |Read an overview of the information in the headers of the given message (PHP 4, PHP 5)
 string imap_fetchbody(resource $imap_stream, int $msg_number, string $section [, int $options=0]) |Fetch a particular section of the body of the message (PHP 4, PHP 5)
@@ -2367,7 +2367,7 @@ int mysqli_thread_id(mysqli $link) |The mysqli_thread_id() function returns the 
 bool mysqli_thread_safe(void) |Tells whether the client library is compiled as thread-safe. (PHP 5, PHP 7)
 mysqli_result mysqli_use_result(mysqli $link) |Used to initiate the retrieval of a result set from the last query executed using the mysqli_real_query() function on the database connection. (PHP 5, PHP 7)
 #Summary of mysqli_stmt methods
-int mysqli_stmt_affected_rows(mysqli_stmt $stmt) |mysqli_stmt::$affected_rows -- mysqli_stmt_affected_rows — Returns the total number of rows changed, deleted, or inserted by the last executed statement. (PHP 5, PHP 7)
+int mysqli_stmt_affected_rows(mysqli_stmt $stmt) |mysqli_stmt::$affected_rows -- mysqli_stmt_affected_rows ï¿½ Returns the total number of rows changed, deleted, or inserted by the last executed statement. (PHP 5, PHP 7)
 int mysqli_stmt_errno(mysqli_stmt $stmt) |Returns the error code for the most recently invoked statement function that can succeed or fail. (PHP 5, PHP 7)
 string mysqli_stmt_error(mysqli_stmt $stmt) |Returns a string containing the error message for the most recently invoked statement function that can succeed or fail. (PHP 5, PHP 7)
 int mysqli_stmt_field_count(mysqli_stmt $stmt) |Returns the number of field in the given statement. (PHP 5, PHP 7)

--- a/app/data/lexlib/Markdown.lcf
+++ b/app/data/lexlib/Markdown.lcf
@@ -656,7 +656,7 @@ object SyntAnal13: TLibSyntAnalyzer
       '[reference][ref] and [reference] [ref]. <HTML> syntax and specia' +
       'l &harr; '
     'chars are highlighted, [Hyperlink text](url "title") '
-    'and ![alternative text](image adress "title"). '
+    'and ![alternative text](image address "title"). '
     'test: ~~~~crossed~ and ~crossed~~~ is supported '
     '- - -'
     '*  *  *'

--- a/app/formframe.pas
+++ b/app/formframe.pas
@@ -732,7 +732,7 @@ procedure TEditorFrame.DoShow;
 var
   an: TecSyntAnalyzer;
 begin
-  //analize file, when frame is shown for the 1st time
+  //analyze file, when frame is shown for the 1st time
   if UiOps.AllowFrameParsing and not FWasVisible then
   begin
     FWasVisible:= true;

--- a/app/formmain_loadsave.inc
+++ b/app/formmain_loadsave.inc
@@ -818,7 +818,7 @@ begin
   if AppPanels[cPaneSide].LastActivePanel<>'' then exit;
 
   S:= FOption_SidebarTab;
-  //if plugin didnt load, caption not valid
+  //if plugin didn't load, caption not valid
   if AppPanels[cPaneSide].CaptionToButtonIndex(S)<0 then
     S:= msgPanelTree_Init;
 

--- a/app/formmain_updates_proc.inc
+++ b/app/formmain_updates_proc.inc
@@ -409,7 +409,7 @@ begin
   end;
 
   ////removed to fix issue:
-  ////search fails, but OnCaret fired and Highlight Occurences gives statusbar message "hilited N matches"
+  ////search fails, but OnCaret fired and Highlight Occurrences gives statusbar message "hilited N matches"
   //Ed.DoEventCarets;
 end;
 

--- a/app/proc_customdialog.pas
+++ b/app/proc_customdialog.pas
@@ -2112,7 +2112,7 @@ begin
       try
         F.ActiveControl:= DoControl_Target(C) as TWinControl;
       except
-        //supress Pascal exception in Py API
+        //suppress Pascal exception in Py API
       end;
     end;
 end;

--- a/app/proc_files.pas
+++ b/app/proc_files.pas
@@ -171,7 +171,7 @@ begin
         end;
       end;
 
-    //Analize table
+    //Analyze table
     if DetectOEM then
       if Result and (TableSize > 0) then
         for i:= Low(Table) to High(Table) do

--- a/app/proc_str.pas
+++ b/app/proc_str.pas
@@ -259,7 +259,7 @@ begin
     Obj.ModifierI:= not ACaseSensitive;
     Obj.ModifierS:= false; //don't catch all text by .*
     Obj.ModifierM:= true; //allow to work with ^$
-    Obj.ModifierX:= false; //don't ingore spaces
+    Obj.ModifierX:= false; //don't ignore spaces
     Result:= Obj.Exec(ASubject) and (Obj.MatchPos[0]=1);
   finally
     Obj.Free;
@@ -278,7 +278,7 @@ begin
     Obj.ModifierI:= not ACaseSensitive;
     Obj.ModifierS:= false; //don't catch all text by .*
     Obj.ModifierM:= true; //allow to work with ^$
-    Obj.ModifierX:= false; //don't ingore spaces
+    Obj.ModifierX:= false; //don't ignore spaces
     NPos:= 1;
     Result:= Obj.Match(UTF8Decode(ASubject), NPos);
   finally

--- a/app/py/cuda_addonman/__init__.py
+++ b/app/py/cuda_addonman/__init__.py
@@ -190,7 +190,7 @@ class Command:
 
         text = _('Download complete') if not self.stopped_force else _('Download stopped ')+self.stopped_msg
         if err>0:
-            text += _('\nErrors occured, see Python console')
+            text += _('\nErrors occurred, see Python console')
         msg_box(text, MB_OK+MB_ICONINFO)
 
 

--- a/app/py/cuda_comments/cd_comments.py
+++ b/app/py/cuda_comments/cd_comments.py
@@ -111,7 +111,7 @@ class Command:
         pass;                  #log('cmt_type, lex, cmt_sgn={}', (cmt_type, lex, cmt_sgn))
         if not cmt_sgn:
             return app.msg_status(f(_('Lexer "{}" doesn\'t support "line comments"'), lex))
-        # Analize
+        # Analyze
         empty_sel   = False
         rWrks       = []
         use_rep_lines = True # use API replace_lines()

--- a/app/py/cuda_comments/cd_plug_lib.py
+++ b/app/py/cuda_comments/cd_plug_lib.py
@@ -346,7 +346,7 @@ def dlg_wrapper(title, w, h, cnts, in_vals={}, focus_cid=None):
             title, w, h     Title, Width, Height 
             cnts            List of static control properties
                                 [{cid:'*', tp:'*', t:1,l:1,w:1,r:1,b;1,h:1, cap:'*', hint:'*', en:'0', props:'*', items:[*], valign_to:'cid'}]
-                                cid         (opt)(str) C(ontrol)id. Need only for buttons and conrols with value (and for tid)
+                                cid         (opt)(str) C(ontrol)id. Need only for buttons and controls with value (and for tid)
                                 tp               (str) Control types from wiki or short names
                                 t           (opt)(int) Top
                                 tid         (opt)(str) Ref to other control cid for horz-align text in both controls

--- a/app/py/cuda_palette/cd_plug_lib.py
+++ b/app/py/cuda_palette/cd_plug_lib.py
@@ -351,7 +351,7 @@ def dlg_wrapper(title, w, h, cnts, in_vals={}, focus_cid=None):
             title, w, h     Title, Width, Height 
             cnts            List of static control properties
                                 [{cid:'*', tp:'*', t:1,l:1,w:1,r:1,b;1,h:1,tid:'cid', cap:'*', hint:'*', en:'0', props:'*', items:[*], act='0'}]
-                                cid         (opt)(str) C(ontrol)id. Need only for buttons and conrols with value (and for tid)
+                                cid         (opt)(str) C(ontrol)id. Need only for buttons and controls with value (and for tid)
                                 tp               (str) Control types from wiki or short names
                                 t           (opt)(int) Top
                                 tid         (opt)(str) Ref to other control cid for horz-align text in both controls

--- a/app/py/cuda_prefs/cd_opts_dlg.py
+++ b/app/py/cuda_prefs/cd_opts_dlg.py
@@ -475,7 +475,7 @@ class OptEdD:
         """ Prepares values for and calls - `do_setv()`
             * action -- set, remove
             * scope -- m.for_ulf -- 'u','l','f' (user, lexer, file)
-            * opname -- optio nname -- m.cur_op
+            * opname -- option name -- m.cur_op
             * lexer -- m.lexr
             * apply_ -- apply options - set True on last option  or  on btn_apply
         """

--- a/app/py/cuda_prefs/dlg.py
+++ b/app/py/cuda_prefs/dlg.py
@@ -46,7 +46,7 @@ import time
 #TODO:
 
 ?
-* different color fo unapplied propery value in editor?
+* different color fo unapplied property value in editor?
 * list changes in dlg-statusbar + hover popup
 * editor line state coloring for modified/unapplied("saved") options?
 * show user/lexer/file option-values for selected option?
@@ -1036,7 +1036,7 @@ class DialogMK2:
             if val == _old_val: # no change - ignore
                 return
         else:  ### removing value
-            if _old_val is None: # no chage - ignore
+            if _old_val is None: # no change - ignore
                 return
 
         # if resetting value -- ask confirmation

--- a/app/py/cuda_prefs/readme/readme.txt
+++ b/app/py/cuda_prefs/readme/readme.txt
@@ -9,7 +9,7 @@ Options are shown in a table, after clicking an option you can see its current v
 - For boolean opts, checkbox is shown to change.
 - For string/number opts, input is shown to change.
 - For opts with limited count of values, combobox is used to choose one variant.
-- For font-name opts, combobox is shown (it lists special OS-dependant "default" font and OS fonts).
+- For font-name opts, combobox is shown (it lists special OS-dependent "default" font and OS fonts).
 
 Clicking on the list header displays a menu to choose visible columns and configure widths.
 

--- a/app/py/cuda_snippet_panel/utils.py
+++ b/app/py/cuda_snippet_panel/utils.py
@@ -27,8 +27,8 @@ def bom_type(file):
     if (b[0:3] == b'\xef\xbb\xbf'):
         return "utf8"
 
-    # Python automatically detects endianess if utf-16 bom is present
-    # write endianess generally determined by endianess of CPU
+    # Python automatically detects endianness if utf-16 bom is present
+    # write endianness generally determined by endianness of CPU
     if ((b[0:2] == b'\xfe\xff') or (b[0:2] == b'\xff\xfe')):
         return "utf16"
 

--- a/app/py/sys/chardet/metadata/languages.py
+++ b/app/py/sys/chardet/metadata/languages.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import, print_function
 from string import ascii_letters
 
 
-# TODO: Add Ukranian (KOI8-U)
+# TODO: Add Ukrainian (KOI8-U)
 
 class Language(object):
     """Metadata about a language useful for training models

--- a/app/py/sys/chardet/sbcharsetprober.py
+++ b/app/py/sys/chardet/sbcharsetprober.py
@@ -127,7 +127,7 @@ class SingleByteCharSetProber(CharSetProber):
                     self._state = ProbingState.FOUND_IT
                 elif confidence < self.NEGATIVE_SHORTCUT_THRESHOLD:
                     self.logger.debug('%s confidence = %s, below negative '
-                                      'shortcut threshhold %s', charset_name,
+                                      'shortcut threshold %s', charset_name,
                                       confidence,
                                       self.NEGATIVE_SHORTCUT_THRESHOLD)
                     self._state = ProbingState.NOT_ME

--- a/app/readme/license.certifi.txt
+++ b/app/readme/license.certifi.txt
@@ -1,4 +1,4 @@
-This packge contains a modified version of ca-bundle.crt:
+This package contains a modified version of ca-bundle.crt:
 
 ca-bundle.crt -- Bundle of CA Root Certificates
 

--- a/app/readme/wiki/cudatext.wiki
+++ b/app/readme/wiki/cudatext.wiki
@@ -47,7 +47,7 @@ Screenshot on Windows:
 * Correctly saves binary files
 * API for inter-line gaps, helping to several plugins (Differ, Insert Pics, Embedded Editor)
 * [[#File_viewer|Viewer for files of unlimited size]]
-* [[#Program_perfomance|Program performance]]
+* [[#Program_performance|Program performance]]
 * [[#Hex_display_of_special_chars|Hex display of special chars]]
 * [[#Tabs_features|Colored UI tabs]]
 * Plugin "Options Editor" to configure CudaText via GUI
@@ -84,7 +84,7 @@ Screenshot on Windows:
 
 = Configs =
 
-CudaText has configuration system in JSON files: call menu item "Options / Settings - default" and you'll see the '''default config'''. You should copy lines from this file to the file from "Options / Settings - user" and edit this '''user config''' - this is the actial config file. Default config is not read by CudaText, it's only to show possible options.
+CudaText has configuration system in JSON files: call menu item "Options / Settings - default" and you'll see the '''default config'''. You should copy lines from this file to the file from "Options / Settings - user" and edit this '''user config''' - this is the actual config file. Default config is not read by CudaText, it's only to show possible options.
 
 You can copy JSON comments too. In the user config, include useful lines in the curly braces "{ }", this is JSON format. Trailing comma before "}" is allowed here.
 
@@ -290,7 +290,7 @@ Dialog "Lexer library" has hotkeys:
 === Lexers on SourceForge ===
 
 Preinstalled lexer library has limited set of lexers.
-Other lexers, which are compatiable with SynWrite editor, are hosted on SF.net:
+Other lexers, which are compatible with SynWrite editor, are hosted on SF.net:
 http://sourceforge.net/projects/synwrite-addons/files/Lexers/
 
 These zip packages can be installed in CudaText: open any zip file via "File / Open" and confirm installation.
@@ -1182,7 +1182,7 @@ But it works only for "editor frame", and don't work for: Console read-only edit
 
 There are two menu items in the View menu:
 
-* Toggle '''Full-screen'''. This maximizes app window (in a special way, OS-dependant, even OS taskbar hides), and also, optionally, turns off some UI elements: toolbar, statusbar, sidebar, side panels (Tree, Project, FTP), bottom panels (Console) etc. Option "ui_fullscreen" has set of chars, each char for one UI element to hide. E.g. option value "tp" hides 2 UI elements ("t" for toolbar, "p" for side panels).
+* Toggle '''Full-screen'''. This maximizes app window (in a special way, OS-dependent, even OS taskbar hides), and also, optionally, turns off some UI elements: toolbar, statusbar, sidebar, side panels (Tree, Project, FTP), bottom panels (Console) etc. Option "ui_fullscreen" has set of chars, each char for one UI element to hide. E.g. option value "tp" hides 2 UI elements ("t" for toolbar, "p" for side panels).
 * Toggle '''Distraction-free'''. Like full-screen, but also all UI elements hide (gutter, statusbar, toolbar, sidebar, side panels). No option currently to configure which elements hide.
 
 Notes:
@@ -1514,7 +1514,7 @@ After markers are placed by Snippets plugin, Tab-key works in special way - it r
 
 Dialog "Save tabs?" shows on CudaText closing, if at least one document is modified and not saved to disk.
 Dialog lists all modified file-tabs (usually one file per one file-tab, but it's allowed to have 2 files in a single file-tab). Checkmarks (all checked by default) are used to check/uncheck file-tabs which will be saved on pressing "Save" button. For untitled documents to be saved, program will show "Save as" prompts.
-Button "Don't save" closes dialog and program, loosing modifications.
+Button "Don't save" closes dialog and program, losing modifications.
 Button "Cancel" closes the dialog, but not the program.
 
 CudaText has the option "ui_reopen_session". When it is true, dialog "Save tabs?" shows additional button: "Don't save / Keep in session", which doesn't save disk files, but stores modified documents to active "session" file. Program will read it on start.
@@ -1662,7 +1662,7 @@ You can make Pull-Request there, if needed.
 
 =Tech topics=
 
-==Program perfomance==
+==Program performance==
 
 ===Startup time===
 
@@ -1672,7 +1672,7 @@ If no additional plugins are installed, or Python engine is disabled (ie not con
 If configuration/history are clean, it starts faster.
 If bottom panel is hidden on start, via option "ui_bottom_on_start":2, it starts faster.
 
-===Perfomance of loading huge files===
+===Performance of loading huge files===
 
 It's interesting how fast Linux editors open huge log files.
 Test file has about 300M size, 4M ASCII lines, it's created by Python script:
@@ -1694,7 +1694,7 @@ PC is HP Pavilion g6, CPU AMD A10 x64, 4 cores, RAM 8G, Ubuntu 18.04. Each time 
 * Emacs GUI 25.2.2: 2 sec., after showing confirmation for big file
 * Bluefish 2.2.10: 24 sec.
 
-===Perfomance on huge lines===
+===Performance on huge lines===
 
 It's interesting how some Linux editors handle huge lines. Tested several editors on Ubuntu 19.10 on Intel i3 CPU. With XML file with a single line of length 4M. XML file contains line like <id name="nnnnnnnnnnnnnnn"> with the huge "name" value of 4M.
 
@@ -1725,7 +1725,7 @@ f.write('">\n')
 
 *    Bluefish 2.2.10. On opening file, gives the warning about too long lines, on choosing "don't split lines" it hanged, waited for 30sec.
 
-===Perfomance of built-in sorting===
+===Performance of built-in sorting===
 
 Test on ~100M text file with short ASCII lines.
 Test on Ubuntu 19.10 on Intel i3 CPU.
@@ -1772,7 +1772,7 @@ Encoding detection works by this pseudo-code:
   if option "def_encoding_utf8":true then
     enc = UTF8
   else
-    enc = ANSI // "ANSI" codepage is OS dependant
+    enc = ANSI // "ANSI" codepage is OS dependent
    
   detect = file_detect_utf8_content
   // it can get 3 values: 
@@ -2184,7 +2184,7 @@ What CudaText folder to pack?
 * On macOS: ~/Library/Application Support/CudaText.
 * On Linux, other Unixes: ~/.config/cudatext, or $XDG_CONFIG_HOME/cudatext if this OS variable is set.
 
-Make the bug reproducable on your CudaText folder on your test file(s). Put your test file(s) in ZIP too. If needed to reproduce the bug, create the [[#Sessions|session]] using Session Manager plugin (bug may be visible only with some session). Put session file in ZIP too (usually it's already in the "settings" subfolder).
+Make the bug reproducible on your CudaText folder on your test file(s). Put your test file(s) in ZIP too. If needed to reproduce the bug, create the [[#Sessions|session]] using Session Manager plugin (bug may be visible only with some session). Put session file in ZIP too (usually it's already in the "settings" subfolder).
 
 ==Behaviour of column selection==
 
@@ -2205,7 +2205,7 @@ Even more weird look happens when user selects column block over word-wrapped li
 Here is the program's logic in all these cases (with full-width characters and with word-wrapped lines). Program calculates (line1, column1) text position of column block left-top edge. Then program calculates (line2, column2) text position of column block right-bottom edge. Then program selects characters in range column1...column2 in all those affected lines line1...line2. And this program logic produces so weird look in word-wrapped mode.
 
 ==How to replace from/to text containing line-breaks==
-There are several ways to perfrom it:
+There are several ways to perform it:
 
 1. The simplest way: set multi-line mode in the Find/Replace dialog, using "+" button. Input fields will become tall and multi-line. To enter line-breaks there, press Ctrl+Enter.
 
@@ -2434,7 +2434,7 @@ Plugin should add sections "bottombar*" ("*" means any substring) to perform the
 
 ====Install.inf lexer lists====
 
-If plugin has many [itemN] sections, it is possible to set list of lexers using vairable (not to write each time "lexers=name,name2,name3"). Declare list of lexers in [info] section like this, any variable name:
+If plugin has many [itemN] sections, it is possible to set list of lexers using variable (not to write each time "lexers=name,name2,name3"). Declare list of lexers in [info] section like this, any variable name:
 
 <syntaxhighlight lang="ini">
 [info]
@@ -2577,7 +2577,7 @@ CudaText: Use option
 
 ST3: Brackets highlight is built-in feature, turned on by default.
 
-CudaText: Brackets highlight is built-in, but it's off by defualt. Use several "bracket_" options, see comments in the "Options Editor" plugin.
+CudaText: Brackets highlight is built-in, but it's off by default. Use several "bracket_" options, see comments in the "Options Editor" plugin.
 
 ==How to highlight pair HTML tags?==
 

--- a/app/readme/wiki/cudatext_api.wiki
+++ b/app/readme/wiki/cudatext_api.wiki
@@ -9,7 +9,7 @@ This is API for [[CudaText]] in Python.
 
 =Event plugins=
 
-To make plugin react to some program event, add method to class Command. For example, method "Command.on_save" will be called by program event "on_save" - if plugin is subscribed to that event. Event methods have param "ed_self": this is Editor object in which event occured. This object is the same as object "ed" in most cases ("ed" always refers to focused editor), but in some cases event occurs in inactive editor, e.g. command "Save all tabs" calls event "on_save" for passive tabs.
+To make plugin react to some program event, add method to class Command. For example, method "Command.on_save" will be called by program event "on_save" - if plugin is subscribed to that event. Event methods have param "ed_self": this is Editor object in which event occurred. This object is the same as object "ed" in most cases ("ed" always refers to focused editor), but in some cases event occurs in inactive editor, e.g. command "Save all tabs" calls event "on_save" for passive tabs.
 
 Plugin can subscribe to events in several ways:
 
@@ -113,7 +113,7 @@ Callback parameter is supported in several API functions: dlg_proc, timer_proc, 
 
 Parameter can be in these forms:
 
-* callable, ie name of a Python function, or just "lambda". Internally, callable will be converted to a weird string. Note that some functions do not support "callable form". You can detect this support by reading the code of "py/cudatext.py" module, which performs the convertions from callable to string.
+* callable, ie name of a Python function, or just "lambda". Internally, callable will be converted to a weird string. Note that some functions do not support "callable form". You can detect this support by reading the code of "py/cudatext.py" module, which performs the conversions from callable to string.
 * string "module=mmm;cmd=nnn;" - to call method nnn (in class Command) in plugin mmm, where mmm is usually sub-dir in the "cudatext/py", but can be any module name
 * string "module=mmm;cmd=nnn;info=iii;" - the same, and callback will get param "info" with your value
 * string "mmm.nnn" - the same, to call method, short form
@@ -183,8 +183,8 @@ Parameter "text" is usually string, but can be of other types (bool, int, float,
 ====app_proc - Misc properties====
 
 * PROC_GET_LANG: Returns string id of active app translation. E.g. "ru_RU" if translation file is "ru_RU.ini", or "translation template" if such file is used. Returns empty string if built-in English translation is used.
-* PROC_GET_GROUPING: Returns grouping mode in program, one of GROUPS_nnnn int contants.
-* PROC_SET_GROUPING: Sets grouping mode in program, one of GROUPS_nnnn int contants.
+* PROC_GET_GROUPING: Returns grouping mode in program, one of GROUPS_nnnn int constants.
+* PROC_SET_GROUPING: Sets grouping mode in program, one of GROUPS_nnnn int constants.
 * PROC_PROGRESSBAR: Changes state of the progress-bar (hidden by default), which is located on the status-bar right corner. Int value<0: progressbar hides, value in 0..100: progressbar shows with the given value.
 
 * PROC_SET_FOLDER: Sets path of folder which will be used as initial folder in program's Open/Save-as dialogs.
@@ -962,7 +962,7 @@ Properties "ex0"..."ex9" are control-specific. They have different simple type (
 ** "ex0": bool: paint border
 ** "ex1": bool: on mouse drag, use instant repainting (else splitter paints after mouse released)
 ** "ex2": bool: auto jump to edge, when size of linked control becomes < min size
-** "ex3": int: mininal size of linked control (controlled by splitter)
+** "ex3": int: minimal size of linked control (controlled by splitter)
 
 ====dlg_custom - Return value====
 
@@ -2157,7 +2157,7 @@ Deletes whole lines from index y1 to y2, then inserts new lines from specified l
 
 * Index y1 must be valid index (0 to count-1)
 * Index y2 can be less than y1 (to not delete), and can be too big (to delete lines to end)
-* Param lines is list/tuple of str. Can be empty list to just delete lines. Inside items should not be "\n" and "\r": "\n" will generate additonal lines, "\r" not handled.
+* Param lines is list/tuple of str. Can be empty list to just delete lines. Inside items should not be "\n" and "\r": "\n" will generate additional lines, "\r" not handled.
 
 Returns bool: index y1 correct, replace done.
 
@@ -2496,7 +2496,7 @@ Param "value" can be: str, number, bool (for bool it can be also "0"/"1"), tuple
 
 ===props vs options===
 
-Many get_prop/set_prop ids correspond to CudaText options. List of correspoding pairs:
+Many get_prop/set_prop ids correspond to CudaText options. List of corresponding pairs:
 
 * PROP_CARET_VIRTUAL - "caret_after_end"
 * PROP_GUTTER_ALL - "gutter_show"
@@ -2650,7 +2650,7 @@ Returns list of ranges which belong to nested lexers (sublexers of current lexer
 
  get_token(id, index1=0, index2=0)
 
-Returns info about lexer "tokens". "Token" is minimal text fragment for lexer, e.g. one indentifier, one operator, one whole comment, one whole string. Each token has its color from lexer properties or color theme. Function returns None if no lexer is active in editor.
+Returns info about lexer "tokens". "Token" is minimal text fragment for lexer, e.g. one identifier, one operator, one whole comment, one whole string. Each token has its color from lexer properties or color theme. Function returns None if no lexer is active in editor.
 
 Possible values of "id":
 
@@ -2992,7 +2992,7 @@ Performs some action in editor. Possible values of "id":
 ** "param2": String with allowed bracket pairs. Can have these pairs: () [] {} <>.
 ** "param3": Max distance, in lines, to the pair bracket. Must be 32-bit signed int.
 
-* EDACTION_SHOW_POS: Make text position visible without caret moving. Returns True if params correct and scrolling occured, returns False if params correct and no scrolling occured, returns None if params not correct.
+* EDACTION_SHOW_POS: Make text position visible without caret moving. Returns True if params correct and scrolling occurred, returns False if params correct and no scrolling occurred, returns None if params not correct.
 ** "param1": Text position as 2-tuple (column, line).
 ** "param2": Indentation of text position from edges as 2-tuple (indent_horz, indent_vert). Values meaning is like for CudaText options "find_indent_horz", "find_indent_vert".
 

--- a/app/readme/wiki/cudatext_plugins.wiki
+++ b/app/readme/wiki/cudatext_plugins.wiki
@@ -80,7 +80,7 @@ Any project can have "main file", you can choose it in the context menu: "Select
 * "Use preview tab on item clicking": If option is on, single click on treeview file item, will open file in "preview tab". Preview tab is single such tab, it's shared by all files, it has italic+underlined tab title. If option is off, clicking file item will open normal tab, separate normal tabs per each file.
 * "Open file after 'Go to file' command": If turned on, command "Project Manager: Go to file" will not only jump to chosen file in the treeview, but also open that file in editor.
 * "Open files by double-click": If turned on, only double-click in the treeview will open file for editing, but not the single click.
-* "On opening file in Git/SVN repo...": On opening any file, Project Manager will check if this file is in the Git/SVN repository (by presense of folder ".git" or ".svn" near the file, or in upper level folders). If yes, Project Manager will create the project from that repository and open it. This gives some slowdown of course.
+* "On opening file in Git/SVN repo...": On opening any file, Project Manager will check if this file is in the Git/SVN repository (by presence of folder ".git" or ".svn" near the file, or in upper level folders). If yes, Project Manager will create the project from that repository and open it. This gives some slowdown of course.
 * "File type icons": Set of file/folder icons for treeview. You can install additional themes from Addons Manager, see category "filetypeicons" there. Example of such theme: "VSCode Material 24x24". This option shows  themes, which are present in the folder "data/filetypeicons".
 * "Toolbar theme": Set of icons for Project Manager toolbar buttons. You can install additional themes from Addon Manager, see the category "projtoolbaricons" there. This option shows themes, which are present in the folder "data/projtoolbaricons".
 
@@ -210,7 +210,7 @@ Snippets are stored in separate files with extensions:
 * .cuda-snippet or .synw-snippet: main format.
 * .cuda-snips: compact format for collections of tiny snippets.
 
-Encoding is UTF-8, no BOM. Files can be placed in any subfolder of "data/snippets" folder, file/folder names have no meaning, but it's recommented to name subfolders like AuthorName.SyntaxName, so users can easily find newly installed snippets.
+Encoding is UTF-8, no BOM. Files can be placed in any subfolder of "data/snippets" folder, file/folder names have no meaning, but it's recommended to name subfolders like AuthorName.SyntaxName, so users can easily find newly installed snippets.
 
 ====Format of .cuda-snippet====
 
@@ -734,7 +734,7 @@ if __name__ == '__main__':
 
 =FindInFiles=
 
-==FiF3 and FiF4: comparision and future==
+==FiF3 and FiF4: comparison and future==
 CudaText now has two plugins to search in files/tabs:
 
 * FindInFiles-v3 (FiF3)
@@ -870,7 +870,7 @@ LSP Client gives several commands in the "Plugins / LSP Client", and all these c
 Some of LSP commands are:
 
 * Auto-completion: integrated with CudaText command "Auto-completion menu" (in the Command Palette).
-* Go to defintion: integrated with CudaText command "Go to definition" (in the Command Palette, and in the editor context menu).
+* Go to definition: integrated with CudaText command "Go to definition" (in the Command Palette, and in the editor context menu).
 * Function signature help: integrated with CudaText command "Show function hint" (in the Command Palette).
 * Hover: shows the tooltip when you hover mouse above identifiers. You need the Ctrl key pressed while you hover.
 * Find references: finds all locations where an identifier (under first caret) is used and shows menu with locations.
@@ -899,7 +899,7 @@ LSP Client also has the settings file, use menu item to open it: "Options / Sett
 Python server has [https://github.com/palantir/python-language-server this homepage] and supports:
 
 * Auto-completion
-* Go to defintion
+* Go to definition
 * Function signature help
 * Hover
 * Find references

--- a/treehelpertester/tests/readme.rst
+++ b/treehelpertester/tests/readme.rst
@@ -780,7 +780,7 @@ You can control what should be printed via several options:
 ``--headers, -h``   Only the response headers are printed.
 ``--body, -b``      Only the response body is printed.
 ``--verbose, -v``   Print the whole HTTP exchange (request and response).
-                    This option also enables ``--all`` (see bellow).
+                    This option also enables ``--all`` (see below).
 ``--print, -p``     Selects parts of the HTTP exchange.
 =================   =====================================================
 
@@ -838,7 +838,7 @@ Print request and response headers:
 Viewing Intermediary Requests/Responses
 ---------------------------------------
 
-To see *all* the HTTP communication, i.e. the final request/resposne as
+To see *all* the HTTP communication, i.e. the final request/response as
 well as any possible  intermediary requests/responses, use the **``--all``**
 option. The intermediary HTTP communication include followed redirects
 (with ``--follow``), the first unauthorized request when HTTP digest


### PR DESCRIPTION
Found via `codespell -q 3 -L ans,ba,hist,ois,pres,te,ue`