### PR TITLE
Update Python.lcf -- Comment style according PEP8

### DIFF
--- a/app/data/lexlib/Python.lcf
+++ b/app/data/lexlib/Python.lcf
@@ -241,7 +241,7 @@ object SyntAnal16: TLibSyntAnalyzer
       DisplayName = 'Comment'
       StyleName = 'Comment'
       TokenType = 1
-      Expression = '\#.*'
+      Expression = '\# .*'
       ColumnFrom = 0
       ColumnTo = 0
     end
@@ -636,7 +636,7 @@ object SyntAnal16: TLibSyntAnalyzer
   CodeTemplates = <>
   SubAnalyzers = <>
   SampleText.Strings = (
-    '#comment'
+    '# comment'
     'test = u"""doc'
     'string""" + r"""doc'
     'string""" + "long \'
@@ -649,7 +649,7 @@ object SyntAnal16: TLibSyntAnalyzer
     'str = r'#39'\test\test'#39' + u'#39'test'#39' + r"\test"'
     'func = lambda x: x'
     ''
-    'def func(num):      #cmt  '
+    'def func(num):      # comment  '
     '    for n in range(len(sys.argv)):'
     '      print("Arg %s" % s)'
     '      if n>2:'
@@ -691,7 +691,7 @@ object SyntAnal16: TLibSyntAnalyzer
   Notes.Strings = (
     'Python lexer by Alexey (CudaText)')
   RestartFromLineStart = True
-  LineComment = '#'
+  LineComment = '# '
   Charset = DEFAULT_CHARSET
   Left = 144
   Top = 184


### PR DESCRIPTION
Block Comments & Inline Comments should start with a # and a single space.
https://www.python.org/dev/peps/pep-0008/#block-comments & https://www.python.org/dev/peps/pep-0008/#inline-comments

also Black (uncompromising! Python code formatter) always insert [space] between #[ ]nextletter


на русском добавлю: этот апдейт содержит костыль, он немножко ломает поведение настроек. лучше использовать с включенной skip blank lines.
также мне кажется, необходимо придумать другой алгоритм обработки комментариев, простой префикс строки уже не рулит и не вывозит.
спасибо