### PR TITLE
Make foreground color more readable against html color background.

### DIFF
--- a/app/formframe.pas
+++ b/app/formframe.pas
@@ -858,8 +858,12 @@ end;
 function _ContrastColor(AColor: TColor): TColor;
 var
   bLight: boolean;
+  red, green, blue: integer;
 begin
-  bLight:= ((AColor and $FF) + (AColor shr 8 and $FF) + (AColor shr 16 and $FF)) >= $180;
+  red := AColor and $FF;
+  green := AColor shr 8 and $FF;
+  blue := AColor shr 16 and $FF;
+  bLight := (red*2) + (green*6) + blue > $500;
   Result:= UiOps.HtmlBackgroundColorPair[bLight];
 end;
 
@@ -4206,4 +4210,3 @@ end;
 
 
 end.
-

--- a/app/formframe.pas
+++ b/app/formframe.pas
@@ -863,6 +863,7 @@ begin
   red := AColor and $FF;
   green := AColor shr 8 and $FF;
   blue := AColor shr 16 and $FF;
+  // Scale red and green to account for perceived intensity. Addresses issue #3624
   bLight := (red*2) + (green*6) + blue > $500;
   Result:= UiOps.HtmlBackgroundColorPair[bLight];
 end;


### PR DESCRIPTION
Scale red and green to account for perceived intensity. Addresses issue #3634 