### PR TITLE
Update app/formframe.pas, address issue #3634

### DIFF
--- a/app/formframe.pas
+++ b/app/formframe.pas
@@ -858,8 +858,19 @@ end;
 function _ContrastColor(AColor: TColor): TColor;
 var
   bLight: boolean;
+  red, green, blue: integer;
 begin
-  bLight:= ((AColor and $FF) + (AColor shr 8 and $FF) + (AColor shr 16 and $FF)) >= $180;
+  red:= AColor and $FF;
+  green:= AColor shr 8 and $FF;
+  blue:= AColor shr 16 and $FF;
+  // Use different scaling with red, green, and blue to account
+  // for perceived intensity. Addresses issue #3624
+  // See https://www.w3.org/TR/AERT/#color-contrast
+  // Color brightness can determined by the following formula:
+  // ((Red value X 299) + (Green value X 587) + (Blue value X 114)) / 1000
+  // ((299+587+114) * 128) = 128000
+  // ((299+587+114) * $80) = $1f400
+  bLight:= red*299 + green*587 + blue*114 > $1f400;
   Result:= UiOps.HtmlBackgroundColorPair[bLight];
 end;
 
@@ -4206,4 +4217,3 @@ end;
 
 
 end.
-


### PR DESCRIPTION
Use different scaling with red, green, and blue to account
for perceived intensity. Addresses issue #3634 
See https://www.w3.org/TR/AERT/#color-contrast
