### PR TITLE
Fixing enum_all_files for file nodes

### DIFF
--- a/app/cudatext.app/Contents/Resources/py/cuda_project_man/__init__.py
+++ b/app/cudatext.app/Contents/Resources/py/cuda_project_man/__init__.py
@@ -1268,8 +1268,12 @@ class Command:
             msg_status(_('Project main file is not set'))
 
     def enum_all_files(self):
-        files = []
-        dirs = self.project['nodes'].copy()
+        files, dirs = [], []
+        for root in self.project['nodes']:
+            if os.path.isdir(root):
+                dirs.append(root)
+            elif os.path.isfile(root):
+                files.append(root)
 
         while dirs:
             try:

--- a/app/py/cuda_project_man/__init__.py
+++ b/app/py/cuda_project_man/__init__.py
@@ -1268,8 +1268,12 @@ class Command:
             msg_status(_('Project main file is not set'))
 
     def enum_all_files(self):
-        files = []
-        dirs = self.project['nodes'].copy()
+        files, dirs = [], []
+        for root in self.project['nodes']:
+            if os.path.isdir(root):
+                dirs.append(root)
+            elif os.path.isfile(root):
+                files.append(root)
 
         while dirs:
             try:


### PR DESCRIPTION
Thank you for committing my earlier pull request. Unfortunately, I introduced an issue where project nodes are ignored if they are files instead of directories. This should fix it, while being just as fast. 