### PR TITLE
attempt to fix #3988

### DIFF
--- a/app/py/cuda_prefs/dlg.py
+++ b/app/py/cuda_prefs/dlg.py
@@ -1338,13 +1338,15 @@ class DialogMK2:
         pass;       LOG and print('APPLY_CHANGES')
 
         # check if current value in edit is changed, create option change if it is
-        try:
-            edit_val = self.val_eds.get_edited_value(self._cur_opt)
-        except ValueError:      # exception happens when trying to cast empty str to float|int
-            edit_val = None
-        if edit_val is not None:
-            # and  edit_val != '': # commented: see CudaText issue #3924
-            self.add_opt_change(self._cur_opt_name, self.scope, edit_val)
+        val_edit_changed = self.val_eds.val_edit.get_prop(PROP_LINE_STATE, 0) != LINESTATE_NORMAL
+        if val_edit_changed:
+            try:
+                edit_val = self.val_eds.get_edited_value(self._cur_opt)
+            except ValueError:      # exception happens when trying to cast empty str to float|int
+                edit_val = None
+            if edit_val is not None:
+                # and  edit_val != '': # commented: see CudaText issue #3924
+                self.add_opt_change(self._cur_opt_name, self.scope, edit_val)
 
         if not self._opt_changes  and  not closing:
             msg_status(_("No option changes has been made"))


### PR DESCRIPTION
added these lines to `def apply_changes`:
```python
val_edit_changed = self.val_eds.val_edit.get_prop(PROP_LINE_STATE, 0)
if val_edit_changed:
```

I think this will correctly check if current string value in edit has been changed. (get_prop(PROP_LINE_STATE) is also used to show modification indicator "[mod]", so I think this is nice way)
if string value is not changed -> do nothing, so "resetting change" will be possible (will not be overwritten by empty value)