### PR TITLE
fix: "open folder containing the current file" command

### DIFF
--- a/app/proc_files.pas
+++ b/app/proc_files.pas
@@ -376,7 +376,7 @@ var
 begin
   if fn='' then exit;
   {$ifdef windows}
-  Params:= '/n,/select,'+fn;
+  Params:= '/n,/select,"'+fn+'"';
   ExecuteProcess('explorer.exe', Params);
   {$else}
   OpenURL(ExtractFileDir(fn));


### PR DESCRIPTION
command was failing for filepaths containing comma char -> `,`