### PR TITLE
Put import-related Python keywords into separate group for lexer.

### DIFF
--- a/app/data/lexlib/Python.cuda-lexmap
+++ b/app/data/lexlib/Python.cuda-lexmap
@@ -11,6 +11,7 @@ Symbol=Symbol
 Comment=Comment
 Id=Id
 Id keyword=Id1
+Id keyword import=Id1
 Id keyword def=IdKeyword
 Id function=Id4
 Id func name=Label

--- a/app/data/lexlib/Python.lcf
+++ b/app/data/lexlib/Python.lcf
@@ -49,6 +49,14 @@ object SyntAnal16: TLibSyntAnalyzer
       Font.Style = []
     end
     item
+      DisplayName = 'Id keyword import'
+      Font.Charset = DEFAULT_CHARSET
+      Font.Color = clNavy
+      Font.Height = -13
+      Font.Name = 'Courier New'
+      Font.Style = []
+    end
+    item
       DisplayName = 'Id keyword def'
       Font.Charset = DEFAULT_CHARSET
       Font.Color = clBlack
@@ -328,6 +336,21 @@ object SyntAnal16: TLibSyntAnalyzer
       HighlightPos = cpAny
       IgnoreAsParent = False
     end
+   item
+      DisplayName = 'Keywords import'
+      StyleName = 'Id keyword import'
+      BlockType = btTagDetect
+      ConditionList = <
+        item
+          TagList.Strings = (
+            'as'
+            'from'
+            'import')
+          TokenTypes = 516
+        end>
+      HighlightPos = cpAny
+      IgnoreAsParent = False
+    end
     item
       DisplayName = 'Keywords'
       StyleName = 'Id keyword'
@@ -336,7 +359,6 @@ object SyntAnal16: TLibSyntAnalyzer
         item
           TagList.Strings = (
             'and'
-            'as'
             'assert'
             'async'
             'await'
@@ -348,9 +370,7 @@ object SyntAnal16: TLibSyntAnalyzer
             'except'
             'finally'
             'for'
-            'from'
             'if'
-            'import'
             'in'
             'is'
             'not'


### PR DESCRIPTION
I've been trying to make the syntax highlighting more like the one used by Xed (the default text editor for Linux Mint) which uses [GtkSourceView](https://wiki.gnome.org/Projects/GtkSourceView/).

It categorises keywords relating to module imports from Python separately - so this merge request attempts to recreate that. It uses the same theme style as for normal keywords, so existing themes should look the same for most users.