### PR TITLE
Put named literals for Python into separate group for lexer.

### DIFF
--- a/app/data/lexlib/Python.cuda-lexmap
+++ b/app/data/lexlib/Python.cuda-lexmap
@@ -15,6 +15,7 @@ Id keyword def=IdKeyword
 Id function=Id4
 Id func name=Label
 Id types=Id2
+Id named literals=Id2
 Id exception=Id3
 Id const=TagId
 Decorator=TagId

--- a/app/data/lexlib/Python.lcf
+++ b/app/data/lexlib/Python.lcf
@@ -81,6 +81,14 @@ object SyntAnal16: TLibSyntAnalyzer
       Font.Style = []
     end
     item
+      DisplayName = 'Id named literals'
+      Font.Charset = DEFAULT_CHARSET
+      Font.Color = clPurple
+      Font.Height = -13
+      Font.Name = 'Courier New'
+      Font.Style = []
+    end
+    item
       DisplayName = 'Id exception'
       Font.Charset = DEFAULT_CHARSET
       Font.Color = clOlive
@@ -461,8 +469,6 @@ object SyntAnal16: TLibSyntAnalyzer
             'bytes'
             'complex'
             'dict'
-            'Ellipsis'
-            'False'
             'file'
             'float'
             'frozenset'
@@ -470,14 +476,29 @@ object SyntAnal16: TLibSyntAnalyzer
             'list'
             'long'
             'memoryview'
-            'None'
             'object'
             'set'
             'slice'
             'str'
-            'True'
             'tuple'
             'unicode')
+          TokenTypes = 516
+        end>
+      HighlightPos = cpAny
+      IgnoreAsParent = False
+    end
+    item
+      DisplayName = 'Named literals'
+      StyleName = 'Id named literals'
+      BlockType = btTagDetect
+      ConditionList = <
+        item
+          TagList.Strings = (
+            'Ellipsis'
+            'False'
+            'None'
+            'NotImplemented'
+            'True')
           TokenTypes = 516
         end>
       HighlightPos = cpAny
@@ -527,7 +548,6 @@ object SyntAnal16: TLibSyntAnalyzer
             'ModuleNotFoundError'
             'NameError'
             'NotADirectoryError'
-            'NotImplemented'
             'NotImplementedError'
             'OSError'
             'OverflowError'


### PR DESCRIPTION
I've been trying to make the syntax highlighting more like the one used by Xed (the default text editor for Linux Mint) which uses [GtkSourceView](https://wiki.gnome.org/Projects/GtkSourceView/).

Currently CudaText defines named literal objects as "types" - even though they are instances of a Python type. A lot (maybe all) of the types mentioned are also functions, but these objects cannot be invoked in the same way.

GtkSourceView defines these literals separately to builtin functions / types - so I've defined them separately as a new group too. (The `NotImplemented` object was also incorrectly defined as an error, which it isn't.) 

It uses the same theme style as for types, so existing themes should look the same for most users.