### PR TITLE
Group Python module names with function / class names in Lexer.

### DIFF
--- a/app/data/lexlib/Python.lcf
+++ b/app/data/lexlib/Python.lcf
@@ -199,7 +199,7 @@ object SyntAnal16: TLibSyntAnalyzer
       DisplayName = 'Id func name'
       StyleName = 'Id func name'
       TokenType = 13
-      Expression = '(?r-i)(?<=\bclass\x20+)\w+ |'#13#10'(?r-i)(?<=\bdef\x20+)\w+'
+      Expression = '(?r-i)(?<=\bclass\x20+)\w+ |(?r-i)(?<=\bfrom\x20+)[\w.]+|'#13#10'(?r-i)(?<=\bdef\x20+)\w+'
       ColumnFrom = 0
       ColumnTo = 0
     end


### PR DESCRIPTION
Like with my other merge requests - this is about making the behaviour more consistent with GtkSourceView.

One difference I noticed is that GtkSourceView will style function names and class names in a certain way - but that will also include module names mentioned in "from module.name import something" type statements.

This doesn't apply for modules mentioned in regular "import module" type statements - it's probably more difficult to do with just a regular expression.

The related code in GtkSourceView is [here](https://gitlab.gnome.org/GNOME/gtksourceview/-/blame/master/data/language-specs/python.lang?ref_type=heads#L220).