### PR TITLE
Release reference of FParamObjs once RunModuleFunction is finished

### DIFF
--- a/app/formmain_py_helpers.inc
+++ b/app/formmain_py_helpers.inc
@@ -473,6 +473,12 @@ begin
     end;
 
     Obj:= AppPython.RunModuleFunction(SModule, SFunc, FParamObjs, FParamNames);
+
+    for i:=0 to Length(FParamObjs)-1 do
+    	begin
+    		AppPython.Engine.Py_DECREF(FParamObjs[i]);
+    	end;
+
     if Assigned(Obj) then
       with AppPython.Engine do
       begin


### PR DESCRIPTION
Otherwise, Python will never garbage collect the objects in the list, leading to a memory leak.

Fixes #5407.