### PR TITLE
custom menubar color qt5 and qt6

### DIFF
--- a/app/formmain.pas
+++ b/app/formmain.pas
@@ -37,6 +37,8 @@ uses
   TreeFilterEdit,
   {$ifdef LCLGTK2}
   fix_gtk_clipboard,
+  {$elseif defined(LCLQt5) or defined(LCLQt6)}
+  qtwidgets,
   {$endif}
   fix_focus_window,
   at__jsonconf, at__fpjson, proc_json_ex,

--- a/app/formmain_themes.inc
+++ b/app/formmain_themes.inc
@@ -57,6 +57,13 @@ begin
   G.Invalidate;
 end;
 
+{$if defined(LCLQt5) or defined(LCLQt6)}
+function bbggrr_to_rrggbb(c: UInt32): UInt32;
+begin
+  Result:= c and $FF shl 16 or c and $FF00 or c shr 16 and $FF;
+end;
+{$endif} 
+
 procedure TfmMain.DoApplyTheme;
 var
   id: TAppPanelId;
@@ -91,12 +98,18 @@ begin
   CodeTreeFilterInput.Update;
 
   ToolbarMain.Color:= GetAppColor(TAppThemeColor.TabBg);
-  Self.Color:= ToolbarMain.Color;
 
   {$if defined(LCLQt5) or defined(LCLQt6)}
-  //fix MainMenu bg-color for dark themes
-  if IsColorDark(Self.Color) then
-    Self.Color:= clMedGray;
+  TQtWidget(MainMenu.Handle).StyleSheet:= Format(
+    'QMenuBar{background:#%.6X}QMenuBar::item:pressed{background:#%.6X}QMenuBar::item{background:transparent;color:#%.6X}',
+    [
+      bbggrr_to_rrggbb(GetAppColor(TAppThemeColor.MenuBg, TAppThemeColor.TabBg)),
+      bbggrr_to_rrggbb(GetAppColor(TAppThemeColor.MenuSelBg, TAppThemeColor.TabOver)),
+      bbggrr_to_rrggbb(GetAppColor(TAppThemeColor.MenuFont, TAppThemeColor.TabFont))
+    ]
+  );
+  {$else}
+  Self.Color:= ToolbarMain.Color;
   {$endif}
 
   PanelCodeTreeTop.Color:= ToolbarMain.Color;

--- a/app/formmain_themes.inc
+++ b/app/formmain_themes.inc
@@ -57,13 +57,6 @@ begin
   G.Invalidate;
 end;
 
-{$if defined(LCLQt5) or defined(LCLQt6)}
-function bbggrr_to_rrggbb(c: UInt32): UInt32;
-begin
-  Result:= c and $FF shl 16 or c and $FF00 or c shr 16 and $FF;
-end;
-{$endif} 
-
 procedure TfmMain.DoApplyTheme;
 var
   id: TAppPanelId;
@@ -100,14 +93,14 @@ begin
   ToolbarMain.Color:= GetAppColor(TAppThemeColor.TabBg);
 
   {$if defined(LCLQt5) or defined(LCLQt6)}
-  TQtWidget(MainMenu.Handle).StyleSheet:= Format(
-    'QMenuBar{background:#%.6X}QMenuBar::item:pressed{background:#%.6X}QMenuBar::item{background:transparent;color:#%.6X}',
-    [
-      bbggrr_to_rrggbb(GetAppColor(TAppThemeColor.MenuBg, TAppThemeColor.TabBg)),
-      bbggrr_to_rrggbb(GetAppColor(TAppThemeColor.MenuSelBg, TAppThemeColor.TabOver)),
-      bbggrr_to_rrggbb(GetAppColor(TAppThemeColor.MenuFont, TAppThemeColor.TabFont))
-    ]
-  );
+  TQtWidget(MainMenu.Handle).StyleSheet:=
+    'QMenuBar{background:'
+    +TATHtmlColorParserA.ColorToHtmlString(GetAppColor(TAppThemeColor.MenuBg, TAppThemeColor.TabBg))
+    +'}QMenuBar::item:pressed{background:'
+    +TATHtmlColorParserA.ColorToHtmlString(GetAppColor(TAppThemeColor.MenuSelBg, TAppThemeColor.TabOver))
+    +'}QMenuBar::item{background:transparent;color:'
+    +TATHtmlColorParserA.ColorToHtmlString(GetAppColor(TAppThemeColor.MenuFont, TAppThemeColor.TabFont))
+    +'}';
   {$else}
   Self.Color:= ToolbarMain.Color;
   {$endif}


### PR DESCRIPTION
colors are same as windows menubar (no background change on hover)

cudatext qt6 navy theme, kde breeze dark color scheme:
<img src='https://github.com/user-attachments/assets/3f732208-3a23-4653-87cb-358508967f11'>