### PR TITLE
Feature for Tabs List plugin - add Drag-and-Drop Tab and Tab Grouping

### DIFF
--- a/app/py/cuda_tabs_list/__init__.py
+++ b/app/py/cuda_tabs_list/__init__.py
@@ -8,6 +8,9 @@ _   = get_translation(__file__)  # I18N
 fn_config = os.path.join(app_path(APP_DIR_SETTINGS), 'cuda_tabs_list.ini')
 fn_icon = 'tabs.png'
 
+CAPTION_GROUP = _('Group')
+CAPTION_FLOATING = _('Floating')
+
 def bool_to_str(v): return '1' if v else '0'
 def str_to_bool(s): return s=='1'
 
@@ -204,10 +207,10 @@ class Command:
             # Add group header if there are multiple groups
             if show_group_headers:
                 if group_idx < 6:
-                    group_name = f"Group {group_idx + 1}"
+                    group_name = f"{CAPTION_GROUP} {group_idx + 1}"
                 else:
                     # Floating groups start at index 6
-                    group_name = f"Floating {group_idx - 5}"
+                    group_name = f"{CAPTION_FLOATING} {group_idx - 5}"
                 
                 # Add group header (non-selectable)
                 listbox_proc(self.h_list, LISTBOX_ADD_PROP, index=-1,


### PR DESCRIPTION
Currently moving a tab position is difficult and cumbersome, we can only move a tab using the horizontal tabs bar, but it is so slow because Cudatext do not auto-scroll the tabs horizontally when the mouse reaches the left/right edges, so the user have to move the tab in steps, first he need to move the tab to the visible edge then use the arrows to move the bar left or right then move again the tab to the edge then move the bar left or right ...etc multiple times until we reach the desired position. this is time consuming and create a bad user experience.

### Summary of Changes and New Features

This PR  introduces two major features for the Tabs List plugin:

1. **Drag-and-Drop Tab Reordering:** You can now click and drag a tab within the list to change its position. This functionality supports:
    
    - **Intra-group reordering:** Moving a tab to a new position within its current group.
        
    - **Cross-group reordering:** Dragging a tab from one group to another.
        
    - This is implemented using new `on_mouse_down` and `on_mouse_up` event handlers for the listbox.
        
    - The `_reorder_tab` method uses the CudaText API (`set_prop` with `PROP_INDEX_TAB` and `PROP_INDEX_GROUP`) to apply the changes to the editor itself.
        
    - A small drag threshold (`drag_threshold`) is used to differentiate between a simple click (which just focuses the tab) and a drag operation.

2. **Tab Grouping:** The list of tabs is no longer a single flat list. It is now **grouped by the CudaText editor group** (e.g., "Group 1", "Group 2", "Floating 1"). This is achieved by:
    
    - Rewriting the `update()` method to sort editors into a dictionary based on `PROP_INDEX_GROUP`.
        
    - Adding visual headers (e.g., `─── Group 1 ───`) to the listbox.
        
 
<img width="1915" height="1011" alt="Untitled" src="https://github.com/user-attachments/assets/80b2eb5d-df37-4b8b-9612-ac299d8d8cad" />

I tested this changes with 2800 opened tab in Cudatext and it worked similar to the original version, I saw no difference in speed when moving tabs, drag-and-drop did not introduce any slowness.