### PR TITLE
Revise clangd installation instructions for Windows

### DIFF
--- a/app/readme/wiki/cudatext_lsp.wiki
+++ b/app/readme/wiki/cudatext_lsp.wiki
@@ -252,17 +252,22 @@ Install one of the servers (case A or case B):
 
 Case A. clangd: https://clangd.llvm.org/installation.html
 
-For Windows, you need to download "clangd-windows-x.x.x.zip" from https://github.com/clangd/clangd/releases . You need to add folder of "clangd.exe" to the OS PATH in Windows settings.
+For Windows, you need the "clangd.exe" and "clang.exe" binaries. You can get it in two ways:
 
-For Windows, you must download the Visual Studio Build Tools:
+**1. Standalone (Lightweight)**
+Download "clangd-windows-x.x.x.zip" from https://github.com/clangd/clangd/releases. Extract it and add the "bin" folder to your OS PATH.
 
-* Download the Visual Studio Build Tools (free) from: https://visualstudio.microsoft.com/downloads/ (scroll to "Tools for Visual Studio" → "Build Tools for Visual Studio").
-* Run the installer.
-* Select the workload "Desktop development with C++".
-* In the optional components, ensure these are checked:
-** "C++ Clang tools for Windows" (optional but useful).
-** The latest MSVC toolset (e.g., MSVC v143 or similar).
-** Windows SDK (usually selected by default).
+**2. Via Compiler Suites (Needed for full auto-completion and headers)**
+If you need clangd to correctly find your project headers and provide full auto-completion, it is better to get it via one of these tools:
+
+* **LLVM Toolchain:** Download the LLVM installer from the LLVM GitHub releases. During installation, select "Add LLVM to the system PATH".
+* **MinGW/MSYS2:** If you use MinGW, install the package "mingw-w64-x86_64-clang-tools-extra".
+* **Visual Studio Build Tools:** ** Download from: https://visualstudio.microsoft.com/downloads/ (scroll to "Tools for Visual Studio" → "Build Tools for Visual Studio").
+** Run the installer and select the workload "Desktop development with C++".
+** In the optional components, ensure these are checked:
+*** "C++ Clang tools for Windows"
+*** The latest MSVC toolset (e.g., MSVC v143 or similar).
+*** Windows SDK (usually selected by default).
 
 Case B. ccls:
 * https://github.com/MaskRay/ccls/wiki/Build
@@ -276,7 +281,7 @@ To use the server in LSP Client, create a file "lsp_c.json" in the "settings" di
     "C": "c"
   },
   "cmd_unix": [
-      "clangd-12",
+      "clangd",
   ],
   "cmd_windows": [
       "clangd",
@@ -284,7 +289,7 @@ To use the server in LSP Client, create a file "lsp_c.json" in the "settings" di
 }
 </syntaxhighlight>
 
-Replace "clangd*" with "ccls" if it was chosen.
+Replace "clangd*" with "ccls" if it was chosen. Note that on some Linux systems, you might need to use a versioned command like "clangd-15".
 
 You can test auto-completion on this sample file main.cpp:
 


### PR DESCRIPTION
Updated installation instructions for clangd on Windows, it was mentioning only visual studio which is so big dependency for just a plugin. i added llvm and msys2 alternatives