### PR TITLE
fix on_state not firing on minimize on Windows and PROC_GET_WINDOW_STATE 

### DIFF
--- a/app/formmain.pas
+++ b/app/formmain.pas
@@ -3462,6 +3462,20 @@ begin
   *)
 
   DoPyEvent_AppActivate(TAppPyEvent.OnAppDeactivate);
+
+  // Fix for on_state not firing on minimize on Windows.
+  // On Windows, TApplicationProperties.OnMinimize does NOT fire when the
+  // user clicks the minimize button (it only fires for programmatic
+  // Application.Minimize). OnDeactivate DOES fire on minimize, but it also
+  // fires on alt-tab / clicking another app. IsIconic checks the actual
+  // OS window state, so we can distinguish minimize from focus loss.
+  // Gated to Windows only: on Linux, AppPropsMinimize already handles it
+  // (and would cause a duplicate if we also emitted here).
+  // https://github.com/Alexey-T/CudaText/issues/6417
+  {$ifdef windows}
+  if IsIconic(Handle) then
+    DoPyEvent_AppState(APPSTATE_WINDOW);
+  {$endif}
 end;
 
 procedure TfmMain.AppPropsDropFiles(Sender: TObject;

--- a/app/formmain_py_api.inc
+++ b/app/formmain_py_api.inc
@@ -6102,12 +6102,26 @@ begin
               i:= WND_FULLSCREEN2
             else if fmMain.ShowFullscreen then
               i:= WND_FULLSCREEN
+            {$ifdef windows}
+            // On Windows, the LCL TForm.WindowState property is NOT reliably
+            // updated to wsMinimized when the user minimizes the window
+            // (the LCL Win32 widgetset doesn't update it on SC_MINIMIZE).
+            // So we query the actual OS-level window state via IsIconic/IsZoomed.
+            // https://github.com/Alexey-T/CudaText/issues/6417
+            else if IsIconic(fmMain.Handle) then
+              i:= WND_MINIMIZED
+            else if IsZoomed(fmMain.Handle) then
+              i:= WND_MAXIMIZED
+            else
+              i:= WND_NORMAL;
+            {$else}
             else if fmMain.WindowState=wsMaximized then
               i:= WND_MAXIMIZED
             else if fmMain.WindowState=wsMinimized then
               i:= WND_MINIMIZED
             else
               i:= WND_NORMAL;
+            {$endif}
             Result:= PyLong_FromLong(Ord(i));
           end;
 


### PR DESCRIPTION
fix on_state not firing on minimize on Windows and fix PROC_GET_WINDOW_STATE returns wrong value when window is minimized
related: https://github.com/Alexey-T/CudaText/issues/6417#issuecomment-5303587961